### PR TITLE
variable name changed due to typo

### DIFF
--- a/webrob/static/index.js
+++ b/webrob/static/index.js
@@ -56,7 +56,7 @@ global.ROS3D  = require('ros3d');
 global.ROSLIB = require('roslib');
 global.EventEmitter2 = require('eventemitter2');
 
-var ros_client = require('@openease/ros-clients');
+var ros_clients = require('@openease/ros-clients');
 global.ROSClient       = ros_clients.ROSClient;
 global.ROSPrologClient = ros_clients.ROSPrologClient;
 


### PR DESCRIPTION
Hi,,

Please check this out, this was due to typo in index.js file-> ros_client**s**

Best,
Abhijit