### PR TITLE
Fix host error with newer docker-compose versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
   nginx:
     image: nginx
     container_name: nginx
-    ports:
-      - "80:80"
-      - "443:443"
+    #ports:
+    #  - "80:80"
+    #  - "443:443"
     #networks:
     #  - openease
     volumes:


### PR DESCRIPTION
For newer docker-compose versions running docker-compose up resulted in the following error:

docker.errors.InvalidArgument: "host" network_mode is incompatible with port_bindings

According to [here](https://forums.docker.com/t/docker-errors-invalidargument-host-network-mode-is-incompatible-with-port-bindings/103492) the problem is that network_mode "host" clashes with port forwarding.

I tried to remove the network_mode but then openEASE wouldn't start. Therefore I removed the port forwarding. This fixed the error and openEASE is running again.