### PR TITLE
Fixed bug if directly starting the tutorial page

### DIFF
--- a/templates/pages/tutorials.html
+++ b/templates/pages/tutorials.html
@@ -36,6 +36,10 @@
             ros = new_ros;
             waitForProlog(ros, function() {
                 console.info('Connected to KnowRob.');
+                const pl = new ROSPrologClient(ros, {});
+                pl.jsonQuery("register_ros_package(openease_rules).", function(result) {
+                    pl.finishClient();
+                });
                 formatter.connect(ros, function() {});
             });
 		}


### PR DESCRIPTION
If the user enters the tutorial page directly, the openease_rule package is not loaded. This is fixed with this PR.